### PR TITLE
chore: unify Renovate config with standard template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":prHourlyLimitNone",
+    ":prConcurrentLimitNone"
+  ],
+  "labels": ["dependencies"],
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge all GitHub Actions updates including major",
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Add semantic commits, dependency labels, PR rate limit presets
- Enable platformAutomerge with squash strategy and gomodTidy post-update
- Add blanket automerge rules for minor/patch/pin/digest updates and all GitHub Actions updates