### PR TITLE
chore(renovate): migrate to shared lexfrei preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,26 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits",
-    ":semanticCommitTypeAll(chore)",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
-  ],
-  "labels": ["dependencies"],
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "postUpdateOptions": ["gomodTidy"],
-  "packageRules": [
-    {
-      "description": "Automerge minor and patch updates",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge all GitHub Actions updates including major",
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    }
-  ]
+  "extends": ["github>lexfrei/renovate-config"]
 }


### PR DESCRIPTION
Replaces the hand-maintained `renovate.json` (a near-copy of the shared preset) with `extends: ["github>lexfrei/renovate-config"]`.

The preset is a strict superset of the previous config and additionally provides the go-directive bump rule, `gomodUpdateImportPaths`, action-digest pinning, the golangci-lint customManager, and the kubernetes grouping — so none of these need to be maintained per repo. Supersedes #19 (which manually added the go-directive rule the preset already includes).