### PR TITLE
fix(build): unpin apk packages in builder stage

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -10,9 +10,9 @@ ARG TARGETARCH
 # Install git and CA certificates for fetching dependencies
 RUN apk update && \
     apk add --no-cache \
-        git=2.49.1-r0 \
-        ca-certificates=20250911-r0 \
-        upx=5.0.2-r0 && \
+        git \
+        ca-certificates \
+        upx && \
     update-ca-certificates
 
 # Create appuser


### PR DESCRIPTION
## Problem

The `Build and Publish Container Images` workflow has failed on every push to master for months (since at least 2026-03-22). The builder stage in `build/Containerfile` pins exact apk revisions:

```text
ERROR: unable to select packages:
  breaks: world[ca-certificates=20250911-r0]
  breaks: world[git=2.49.1-r0]
```

Those exact `-r0` revisions have aged out of the Alpine repository (current `git` is 2.52.0), so `apk add` can no longer select them.

## Fix

Drop the version pins for `git`, `ca-certificates`, `upx`. They are build-stage tools only — the final image is `FROM scratch` — so an exact revision pin adds little reproducibility while breaking constantly as Alpine rolls revisions. This matches the unpinned root `Dockerfile`.

Verified locally: `apk add --no-cache git ca-certificates upx` on `golang:1.26-alpine` installs cleanly (git 2.52.0).