### PR TITLE
fix(build): re-pin apk packages to current Alpine 3.23 revisions

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -10,9 +10,9 @@ ARG TARGETARCH
 # Install git and CA certificates for fetching dependencies
 RUN apk update && \
     apk add --no-cache \
-        git \
-        ca-certificates \
-        upx && \
+        git=2.52.0-r0 \
+        ca-certificates=20260413-r0 \
+        upx=5.0.2-r0 && \
     update-ca-certificates
 
 # Create appuser


### PR DESCRIPTION
Restores exact apk version pins in the builder stage with the revisions currently shipped by `golang:1.26-alpine` (Alpine 3.23):

- `git=2.52.0-r0` (was `2.49.1-r0`, aged out)
- `ca-certificates=20260413-r0` (was `20250911-r0`, aged out)
- `upx=5.0.2-r0` (unchanged, still valid)

The old revisions had been removed from the Alpine repository, so `apk add` failed with `unable to select packages` on every build. Pinning is kept (the prior unpin was a stopgap); these are pinned to the current available revisions.

Verified locally on `golang:1.26-alpine`: `apk add --no-cache git=2.52.0-r0 ca-certificates=20260413-r0 upx=5.0.2-r0` installs cleanly.