### PR TITLE
chore(build): annotate apk pins for Renovate repology tracking

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -10,8 +10,11 @@ ARG TARGETARCH
 # Install git and CA certificates for fetching dependencies
 RUN apk update && \
     apk add --no-cache \
+        # renovate: datasource=repology depName=alpine_3_23/git versioning=loose
         git=2.52.0-r0 \
+        # renovate: datasource=repology depName=alpine_3_23/ca-certificates versioning=loose
         ca-certificates=20260413-r0 \
+        # renovate: datasource=repology depName=alpine_3_23/upx versioning=loose
         upx=5.0.2-r0 && \
     update-ca-certificates
 


### PR DESCRIPTION
Adds `# renovate: datasource=repology depName=alpine_3_23/<pkg> versioning=loose` comments above the `git`/`ca-certificates`/`upx` pins in the builder stage.

Paired with the shared preset's apk customManager (lexfrei/renovate-config#2), Renovate will now bump these pins as Alpine ships new revisions, so they no longer silently age out and break the build.

Verified locally that the comments inside the `apk add` line continuation are stripped by BuildKit and do not change the resulting command or break the build.